### PR TITLE
Feature/support custom model implementations

### DIFF
--- a/environment_mlflow_client/env_mlflow_client.py
+++ b/environment_mlflow_client/env_mlflow_client.py
@@ -135,15 +135,22 @@ class EnvMlflowClient(mlflow.tracking.MlflowClient):
         name = self.get_env_model_name(name)
         return super().get_model_version(name=name, version=version)
 
-    def load_model_version(self, model_flavor, name: str, version: str) -> Any:
+    def load_model_version(
+        self, model_flavor, name: str, version: str, unwrap_model: bool = False
+    ) -> Any:
         """Load a model version within the specified stage"""
         model_version = self.get_model_version(
             name=name,
             version=version,
         )
-        return model_flavor.load_model(model_uri=model_version.source)
+        model = model_flavor.load_model(model_uri=model_version.source)
+        if unwrap_model:
+            model = model._model_impl  # retrieve custom model implementation
+        return model
 
-    def load_latest_model(self, model_flavor, name: str) -> Any:
+    def load_latest_model(
+        self, model_flavor, name: str, unwrap_model: bool = False
+    ) -> Any:
         """
         Load the latest version of the pyfunc model with the given name.
 
@@ -155,7 +162,10 @@ class EnvMlflowClient(mlflow.tracking.MlflowClient):
             The loaded model
         """
         latest_versions = self.get_latest_versions(name)
-        return model_flavor.load_model(latest_versions[0].source)
+        model = model_flavor.load_model(latest_versions[0].source)
+        if unwrap_model:
+            model = model._model_impl  # retrieve custom model implementation
+        return model
 
     def log_model_helper(
         self, model_flavor: Any, registered_model_name: str, **kwargs

--- a/tests/model/model_loader.py
+++ b/tests/model/model_loader.py
@@ -12,7 +12,7 @@ def _load_pyfunc(path: str):
     """
     table_path = Path(path) / "table.json"
 
-    with open(table_path, "r") as table_file:
+    with open(table_path, mode="r", encoding="utf-8") as table_file:
         lookup_table = json.load(table_file)
 
     model_path = Path(path) / "model.p"

--- a/tests/model/model_loader.py
+++ b/tests/model/model_loader.py
@@ -1,0 +1,24 @@
+import json
+import pickle
+from pathlib import Path
+from typing import Optional, Dict
+
+import mlflow
+
+
+def _load_pyfunc(path: str):
+    """
+    This function is required by mlflow for loading the model, and returns an object with a 'predict' function
+    """
+    table_path = Path(path) / "table.json"
+
+    with open(table_path, "r") as table_file:
+        lookup_table = json.load(table_file)
+
+    model_path = Path(path) / "model.p"
+    with open(model_path, "rb") as model_file:
+        model = pickle.load(model_file)
+
+    model.lookup_table = lookup_table
+
+    return model

--- a/tests/test_custom_model_with_artifacts.py
+++ b/tests/test_custom_model_with_artifacts.py
@@ -1,0 +1,63 @@
+import json
+import pickle
+import tempfile
+from pathlib import Path
+
+import mlflow
+import pytest
+
+from environment_mlflow_client import EnvMlflowClient
+
+TEST_MODEL_NAME = "test_model_name"
+ENV_NAME = "local"
+LOOKUP_TABLE = {"column_1": [1, 2, 3]}
+
+
+class FakeModel(mlflow.pyfunc.PythonModel):
+    def predict(self, context, model_input):
+        return None
+
+
+@pytest.fixture(autouse=True, scope="module")
+def log_model_with_artifacts(run_mlflow):
+    model_flavor = mlflow.pyfunc
+    client = EnvMlflowClient(env_name=ENV_NAME)
+
+    experiment_id = client.create_experiment_if_not_exists("unittest")
+
+    with mlflow.start_run(run_name="unittest_training", experiment_id=experiment_id):
+
+        with tempfile.TemporaryDirectory() as model_dir:
+            table_path = Path(model_dir) / "table.json"
+
+            with open(table_path, "w") as table_file:
+                table = LOOKUP_TABLE
+                json.dump(table, table_file)
+
+            model_path = Path(model_dir) / "model.p"
+            with open(model_path, "wb") as model_file:
+                model = FakeModel()
+                pickle.dump(model, model_file)
+
+            model_code_path = Path(__file__).parent / "model"
+
+            model_version, model_info = client.log_model_helper(
+                model_flavor=model_flavor,
+                registered_model_name=TEST_MODEL_NAME,
+                loader_module="model_loader",
+                artifact_path=TEST_MODEL_NAME,
+                data_path=model_dir,
+                code_path=[model_code_path],
+            )
+    assert model_version.name == client.get_env_model_name(TEST_MODEL_NAME)
+    assert model_info.artifact_path == client.get_env_model_name(TEST_MODEL_NAME)
+    assert model_version.current_stage == "Staging"
+
+
+def test_registered_model_has_artifacts():
+    """test loading of PyFuncModel with artifacts with custom lookup table"""
+    client = EnvMlflowClient(env_name="local")
+    model = client.load_latest_model(
+        model_flavor=mlflow.pyfunc, name=TEST_MODEL_NAME, unwrap_model=True
+    )
+    assert model.lookup_table == LOOKUP_TABLE

--- a/tests/test_custom_model_with_artifacts.py
+++ b/tests/test_custom_model_with_artifacts.py
@@ -54,10 +54,19 @@ def log_model_with_artifacts(run_mlflow):
     assert model_version.current_stage == "Staging"
 
 
-def test_registered_model_has_artifacts():
-    """test loading of PyFuncModel with artifacts with custom lookup table"""
+def test_custom_model_with_artifacts():
+    """test loading of underlying model with artifacts with custom lookup table"""
     client = EnvMlflowClient(env_name="local")
     model = client.load_latest_model(
         model_flavor=mlflow.pyfunc, name=TEST_MODEL_NAME, unwrap_model=True
     )
     assert model.lookup_table == LOOKUP_TABLE
+    assert hasattr(model, "predict")
+
+
+def test_wrapped_model_with_artifacts():
+    """test loading of PyFuncModel with artifacts"""
+    client = EnvMlflowClient(env_name="local")
+    model = client.load_latest_model(model_flavor=mlflow.pyfunc, name=TEST_MODEL_NAME)
+    assert hasattr(model, "lookup_table") is False
+    assert hasattr(model, "predict")

--- a/tests/test_custom_model_with_artifacts.py
+++ b/tests/test_custom_model_with_artifacts.py
@@ -8,7 +8,7 @@ import pytest
 
 from environment_mlflow_client import EnvMlflowClient
 
-TEST_MODEL_NAME = "test_model_name"
+TEST_MODEL_NAME = "test_custom_model_with_artifacts"
 ENV_NAME = "local"
 LOOKUP_TABLE = {"column_1": [1, 2, 3]}
 

--- a/tests/test_custom_model_with_artifacts.py
+++ b/tests/test_custom_model_with_artifacts.py
@@ -14,12 +14,15 @@ LOOKUP_TABLE = {"column_1": [1, 2, 3]}
 
 
 class FakeModel(mlflow.pyfunc.PythonModel):
+    """Fake model to log"""
+
     def predict(self, context, model_input):
         return None
 
 
 @pytest.fixture(autouse=True, scope="module")
-def log_model_with_artifacts(run_mlflow):
+def log_model_with_artifacts():
+    """Log a custom pyfunc model and its artifacts"""
     model_flavor = mlflow.pyfunc
     client = EnvMlflowClient(env_name=ENV_NAME)
 
@@ -30,7 +33,7 @@ def log_model_with_artifacts(run_mlflow):
         with tempfile.TemporaryDirectory() as model_dir:
             table_path = Path(model_dir) / "table.json"
 
-            with open(table_path, "w") as table_file:
+            with open(table_path, mode="w", encoding="utf-8") as table_file:
                 table = LOOKUP_TABLE
                 json.dump(table, table_file)
 

--- a/tests/test_env_mlflow_client.py
+++ b/tests/test_env_mlflow_client.py
@@ -3,7 +3,7 @@ import pytest
 
 from environment_mlflow_client import EnvMlflowClient
 
-TEST_MODEL_NAME = "test_model_name"
+TEST_MODEL_NAME = "test_custom_model_with_artifacts"
 ENV_NAME = "local"
 
 

--- a/tests/test_env_mlflow_client.py
+++ b/tests/test_env_mlflow_client.py
@@ -8,12 +8,15 @@ ENV_NAME = "local"
 
 
 class FakeModel(mlflow.pyfunc.PythonModel):
+    """Fake model to log"""
+
     def predict(self, context, model_input):
         return None
 
 
 @pytest.fixture(autouse=True, scope="module")
-def log_model(run_mlflow):
+def log_model():
+    """log a pyfunc model directly"""
     model_flavor = mlflow.pyfunc
     client = EnvMlflowClient(env_name=ENV_NAME)
 

--- a/tests/test_env_mlflow_client.py
+++ b/tests/test_env_mlflow_client.py
@@ -3,7 +3,7 @@ import pytest
 
 from environment_mlflow_client import EnvMlflowClient
 
-TEST_MODEL_NAME = "test_custom_model_with_artifacts"
+TEST_MODEL_NAME = "test_model_name"
 ENV_NAME = "local"
 
 


### PR DESCRIPTION
allow returning the underlying custom python implementations of models and shed the outer pyfuncmodel wrapper. it is confusing that after the custom `_load_pyfunc` is called the object is wrapped and loses direct access to its custom attributes and methods. This allows the user to choose to drop the outer wrapper when loading a model.